### PR TITLE
blocking_connection: Fix consume() return type

### DIFF
--- a/pika-stubs/adapters/blocking_connection.pyi
+++ b/pika-stubs/adapters/blocking_connection.pyi
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import types
-from typing import Any, Callable, List, Mapping, Optional, Tuple, Type
+from typing import Any, Callable, Iterator, List, Mapping, Optional, Tuple, Type
 
 from .. import channel, connection, frame, spec
 
@@ -147,7 +147,13 @@ class BlockingChannel:
         exclusive: bool = ...,
         arguments: Optional[Mapping[str, Any]] = ...,
         inactivity_timeout: Optional[float] = ...,
-    ) -> None: ...
+    ) -> Iterator[
+        Tuple[
+            Optional[spec.Basic.Deliver],
+            Optional[spec.BasicProperties],
+            Optional[bytes],
+        ]
+    ]: ...
 
     def get_waiting_message_count(self) -> int: ...
 


### PR DESCRIPTION
`consume()` returns an iterator, not `None` ([documentation](https://pika.readthedocs.io/en/stable/modules/adapters/blocking.html#pika.adapters.blocking_connection.BlockingChannel.consume)).

Fixes #3.