### PR TITLE
Remove python_requires restriction

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ classifiers =
 [options]
 packages = pika-stubs
 include_package_data = True
-python_requires = >=3.8
 install_requires =
 
 [options.extras_require]


### PR DESCRIPTION
Mypy supports new Python features in stubs even when running on older Python versions. And at runtime, by definition, type stubs are not used or even imported at all. So there is no reason to restrict the Python version.

Fixes #1.