### PR TITLE
Fix type for `BlockingConnection.queue_declare.arguments`

### DIFF
--- a/pika-stubs/adapters/blocking_connection.pyi
+++ b/pika-stubs/adapters/blocking_connection.pyi
@@ -229,7 +229,7 @@ class BlockingChannel:
         durable: bool = ...,
         exclusive: bool = ...,
         auto_delete: bool = ...,
-        arguments: Optional[spec.Queue.DeclareOk] = ...,
+        arguments: Optional[Mapping[str, Any]] = ...,
     ) -> frame.Method[spec.Queue.DeclareOk]: ...
 
     def queue_delete(


### PR DESCRIPTION
It looks like there was a typo for the type of the `arguments` field of the `declare_queue`  method of a `BlockingConnection`. 